### PR TITLE
Version 0.42-alpha - Cross-Account Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Go Report Card](https://goreportcard.com/badge/github.com/daidokoro/qaz)
 
 
-__Qaz__ is a Fork of the Bora project by [@pkazmierczak](https://github.com/pkazmierczak)that focuses on simplifying the process of deploying infrastructure on AWS via Cloudformation by utilising the Go Templates Library and custom functions to generate diverse and configurable templates.
+__Qaz__ is a AWS Cloudformation Template Management CLI tool inspired by the Bora project by [@pkazmierczak](https://github.com/pkazmierczak) that focuses on simplifying the process of deploying infrastructure on AWS via Cloudformation by utilising the Go Templates Library and custom functions to generate diverse and configurable templates.
 
 Qaz emphasizes minimal abstraction from the underlying AWS Cloudformation Platform. It instead enhances customisability and re-usability of templates through dynamic template generation and logic.
 
@@ -34,6 +34,7 @@ Qaz emphasizes minimal abstraction from the underlying AWS Cloudformation Platfo
 
 - *Encryption* & *Decryption* of template values & deployment of encrypted templates using AWS KMS.
 
+- Simultaneous Cross-Account Stack Deployments.
 
 ## Installation
 
@@ -414,14 +415,6 @@ See `examples` folder for more examples of usage. More examples to come.
 
 ```
 $ qaz
-                   
-  __ _   __ _  ____
- / _` | / _` ||_  /
-| (_| || (_| | / / 
- \__, | \__,_|/___|
-    |_|            
-
---> Shut up & deploy my templates...!
 
 Usage:
   qaz [flags]
@@ -449,7 +442,6 @@ Flags:
 
 Use "qaz [command] --help" for more information about a command.
 
-
 ```
 
 
@@ -464,5 +456,9 @@ Qaz is in early development.
 - Qaz can already create Azure Templates, Once I get my head around Azure as a Platform, i'll add support for Deploying to Azure as well..... Maybe
 
 --
+
+# Contributing
+
+Fork -> Patch -> Push -> Pull Request
 
 _Pull requests welcomed...._

--- a/commands/aws.go
+++ b/commands/aws.go
@@ -24,7 +24,7 @@ func (s *sessionManager) GetSess(p string) (*session.Session, error) {
 	}
 
 	if _, ok := s.sessions[p]; ok {
-		fmt.Println("Session:", ok)
+		Log(fmt.Sprintf("Session Detected: [%s]", p), level.debug)
 		return s.sessions[p], nil
 	}
 

--- a/commands/change.go
+++ b/commands/change.go
@@ -92,8 +92,11 @@ var rm = &cobra.Command{
 			return
 		}
 
-		s := &stack{name: job.stackName}
-		s.setStackName()
+		if _, ok := stacks[job.stackName]; !ok {
+			handleError(fmt.Errorf("Stack not found: [%s]", job.stackName))
+		}
+
+		s := stacks[job.stackName]
 
 		if err := s.change("rm"); err != nil {
 			handleError(err)
@@ -119,8 +122,11 @@ var list = &cobra.Command{
 			return
 		}
 
-		s := &stack{name: job.stackName}
-		s.setStackName()
+		if _, ok := stacks[job.stackName]; !ok {
+			handleError(fmt.Errorf("Stack not found: [%s]", job.stackName))
+		}
+
+		s := stacks[job.stackName]
 
 		if err := s.change("list"); err != nil {
 			handleError(err)
@@ -152,8 +158,11 @@ var execute = &cobra.Command{
 			return
 		}
 
-		s := &stack{name: job.stackName}
-		s.setStackName()
+		if _, ok := stacks[job.stackName]; !ok {
+			handleError(fmt.Errorf("Stack not found: [%s]", job.stackName))
+		}
+
+		s := stacks[job.stackName]
 
 		if err := s.change("execute"); err != nil {
 			handleError(err)
@@ -185,15 +194,11 @@ var desc = &cobra.Command{
 			return
 		}
 
-		s := &stack{name: job.stackName}
-		s.setStackName()
-
-		// create session
-		s.session, err = manager.GetSess(s.profile)
-		if err != nil {
-			handleError(err)
-			return
+		if _, ok := stacks[job.stackName]; !ok {
+			handleError(fmt.Errorf("Stack not found: [%s]", job.stackName))
 		}
+
+		s := stacks[job.stackName]
 
 		if err := s.change("desc"); err != nil {
 			handleError(err)

--- a/commands/change.go
+++ b/commands/change.go
@@ -61,14 +61,7 @@ var create = &cobra.Command{
 			handleError(err)
 		}
 
-		// create session
-		sess, err := awsSession()
-		if err != nil {
-			handleError(err)
-			return
-		}
-
-		if err := stacks[s].change(sess, "create"); err != nil {
+		if err := stacks[s].change("create"); err != nil {
 			handleError(err)
 		}
 
@@ -102,14 +95,7 @@ var rm = &cobra.Command{
 		s := &stack{name: job.stackName}
 		s.setStackName()
 
-		// create session
-		sess, err := awsSession()
-		if err != nil {
-			handleError(err)
-			return
-		}
-
-		if err := s.change(sess, "rm"); err != nil {
+		if err := s.change("rm"); err != nil {
 			handleError(err)
 		}
 
@@ -136,14 +122,7 @@ var list = &cobra.Command{
 		s := &stack{name: job.stackName}
 		s.setStackName()
 
-		// create session
-		sess, err := awsSession()
-		if err != nil {
-			handleError(err)
-			return
-		}
-
-		if err := s.change(sess, "list"); err != nil {
+		if err := s.change("list"); err != nil {
 			handleError(err)
 		}
 	},
@@ -176,14 +155,7 @@ var execute = &cobra.Command{
 		s := &stack{name: job.stackName}
 		s.setStackName()
 
-		// create session
-		sess, err := awsSession()
-		if err != nil {
-			handleError(err)
-			return
-		}
-
-		if err := s.change(sess, "execute"); err != nil {
+		if err := s.change("execute"); err != nil {
 			handleError(err)
 		}
 	},
@@ -217,13 +189,13 @@ var desc = &cobra.Command{
 		s.setStackName()
 
 		// create session
-		sess, err := awsSession()
+		s.session, err = manager.GetSess(s.profile)
 		if err != nil {
 			handleError(err)
 			return
 		}
 
-		if err := s.change(sess, "desc"); err != nil {
+		if err := s.change("desc"); err != nil {
 			handleError(err)
 		}
 	},

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/CrowdSurge/banner"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/spf13/cobra"
 )
 
@@ -252,13 +251,7 @@ var updateCmd = &cobra.Command{
 			handleError(err)
 		}
 
-		// Update stack
-		sess, err := awsSession()
-		if err != nil {
-			handleError(err)
-			return
-		}
-		stacks[s].update(sess)
+		stacks[s].update()
 
 	},
 }
@@ -306,16 +299,10 @@ var statusCmd = &cobra.Command{
 			return
 		}
 
-		sess, err := awsSession()
-		if err != nil {
-			handleError(err)
-			return
-		}
-
 		for _, v := range stacks {
 			wg.Add(1)
 			go func(s *stack) {
-				if err := s.status(sess); err != nil {
+				if err := s.status(); err != nil {
 					handleError(err)
 				}
 				wg.Done()
@@ -345,12 +332,6 @@ var outputsCmd = &cobra.Command{
 			return
 		}
 
-		sess, err := awsSession()
-		if err != nil {
-			handleError(err)
-			return
-		}
-
 		for _, s := range args {
 			// check if stack exists
 			if _, ok := stacks[s]; !ok {
@@ -360,7 +341,7 @@ var outputsCmd = &cobra.Command{
 
 			wg.Add(1)
 			go func(s string) {
-				if err := stacks[s].outputs(sess); err != nil {
+				if err := stacks[s].outputs(); err != nil {
 					handleError(err)
 				}
 
@@ -387,7 +368,7 @@ var exportsCmd = &cobra.Command{
 
 		job.request = "exports"
 
-		sess, err := awsSession()
+		sess, err := manager.GetSess(job.profile)
 		if err != nil {
 			handleError(err)
 			return
@@ -437,13 +418,13 @@ var checkCmd = &cobra.Command{
 		stk.setStackName()
 		stk.template = tpl
 
-		sess, err := awsSession()
+		stk.session, err = manager.GetSess(stk.profile)
 		if err != nil {
 			handleError(err)
 			return
 		}
 
-		if err := stk.check(sess); err != nil {
+		if err := stk.check(); err != nil {
 			handleError(err)
 			return
 		}
@@ -462,7 +443,7 @@ var invokeCmd = &cobra.Command{
 			return
 		}
 
-		sess, err := awsSession()
+		sess, err := manager.GetSess(job.profile)
 		if err != nil {
 			handleError(err)
 			return
@@ -506,20 +487,15 @@ var policyCmd = &cobra.Command{
 			return
 		}
 
-		sess, err := awsSession()
-		if err != nil {
-			handleError(err)
-		}
-
 		for _, s := range args {
 			wg.Add(1)
-			go func(s string, sess *session.Session) {
+			go func(s string) {
 
 				if _, ok := stacks[s]; !ok {
 					handleError(fmt.Errorf("Stack [%s] not found in config", s))
 
 				} else {
-					if err := stacks[s].stackPolicy(sess); err != nil {
+					if err := stacks[s].stackPolicy(); err != nil {
 						handleError(err)
 					}
 				}
@@ -527,7 +503,7 @@ var policyCmd = &cobra.Command{
 				wg.Done()
 				return
 
-			}(s, sess)
+			}(s)
 		}
 
 		wg.Wait()

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -36,7 +36,7 @@ var wg sync.WaitGroup
 // RootCmd command (calls all other commands)
 var RootCmd = &cobra.Command{
 	Use:   "qaz",
-	Short: fmt.Sprintf("%s\n--> Shut up & deploy my templates...!", colorString(banner.PrintS("qaz"), "magenta")),
+	Short: fmt.Sprintf("\n"),
 	Run: func(cmd *cobra.Command, args []string) {
 
 		if job.version {
@@ -66,7 +66,7 @@ var initCmd = &cobra.Command{
 		}
 
 		// Get Project & AWS Region
-		project = getInput("-> Enter your Project name", "MyqazProject")
+		project = getInput("-> Enter your Project name", "qaz-project")
 		region = getInput("-> Enter AWS Region", "eu-west-1")
 
 		// set target paths

--- a/commands/config.go
+++ b/commands/config.go
@@ -15,11 +15,13 @@ var config Config
 type Config struct {
 	Region  string                 `yaml:"region,omitempty"`
 	Project string                 `yaml:"project"`
+	Bucket  string                 `yaml:"bucket"`
 	Global  map[string]interface{} `yaml:"global,omitempty"`
 	Stacks  map[string]struct {
 		DependsOn  []string               `yaml:"depends_on,omitempty"`
 		Parameters []map[string]string    `yaml:"parameters,omitempty"`
 		Policy     string                 `yaml:"policy,omitempty"`
+		Profile    string                 `yaml:"profile,omitempty"`
 		CF         map[string]interface{} `yaml:"cf"`
 	} `yaml:"stacks"`
 }
@@ -79,6 +81,15 @@ func configReader(conf string) error {
 		stacks[s].setStackName()
 		stacks[s].dependsOn = v.DependsOn
 		stacks[s].policy = v.Policy
+		stacks[s].profile = v.Profile
+
+		// set session
+		sess, err := manager.GetSess(stacks[s].profile)
+		if err != nil {
+			return err
+		}
+
+		stacks[s].session = sess
 
 		// set parameters, if any
 		config.parameters(stacks[s])

--- a/commands/helpers.go
+++ b/commands/helpers.go
@@ -25,33 +25,18 @@ import (
 // configTemplate - Returns template byte string for init() function
 func configTemplate(project string, region string) []byte {
 	return []byte(fmt.Sprintf(`
-# Specify the AWS region code
-# qaz will attempt to get it from AWS configuration
-# or from the environment. This setting overrides
-# every other.
-
+# AWS Region
 region: %s
 
-# Required: specify the name of the Project
-# (qaz will prepend this value to the stack
-# names defined below.
-
+# Project Name
 project: %s
 
-# Optional: global values accisible accross
-# all stacks can be define under global
-
+# Global Stack Variables
 global:
 
-# Stack-specific variables and
-# arbitrary keys cab be defined here,
-# Under the [stacks] key word,
-
+# Stacks
 stacks:
-  # Note that the stack name must match the file name of the template file. The extension does not need to be specified.
-  your_stack_name_here:
-    cf:
-      your_key/value_pairs_here:
+
 `, region, project))
 }
 

--- a/commands/helpers.go
+++ b/commands/helpers.go
@@ -158,7 +158,7 @@ func Get(url string) (string, error) {
 // S3Read - Reads the content of a given s3 url endpoint and returns the content string.
 func S3Read(url string) (string, error) {
 
-	sess, err := awsSession()
+	sess, err := manager.GetSess(job.profile)
 	if err != nil {
 		return "", err
 	}

--- a/commands/helpers_test.go
+++ b/commands/helpers_test.go
@@ -14,7 +14,8 @@ func TestGetSource(t *testing.T) {
 
 // TestAwsSession - tests this awsSession function
 func TestAwsSession(t *testing.T) {
-	if _, err := awsSession(); err != nil {
+
+	if _, err := manager.GetSess("default"); err != nil {
 		t.Error(err.Error())
 	}
 }
@@ -26,7 +27,7 @@ func TestInvoke(t *testing.T) {
 		payload: []byte(`{"name":"qaz"}`),
 	}
 
-	sess, err := awsSession()
+	sess, err := manager.GetSess("default")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -38,7 +39,7 @@ func TestInvoke(t *testing.T) {
 
 // TestExports - test Excport function
 func TestExports(t *testing.T) {
-	sess, err := awsSession()
+	sess, err := manager.GetSess("default")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/commands/stack.go
+++ b/commands/stack.go
@@ -162,6 +162,7 @@ func (s *stack) terminate() error {
 	go s.tail("DELETE", done)
 
 	if err != nil {
+		done <- true
 		return errors.New(fmt.Sprintln("Deleting failed: ", err))
 	}
 

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,4 +1,4 @@
 package commands
 
 // Version
-const version = "v0.41-alpha"
+const version = "v0.42-alpha"

--- a/examples/multi-account/Readme.md
+++ b/examples/multi-account/Readme.md
@@ -1,0 +1,66 @@
+# Multi-Account Deployment
+
+This example shows the setup for a multiple AWS account deployment.
+
+This feature explicitly requires AWS Account credentials to be configured correctly.
+
+
+For this example, here's my aws config:
+
+```toml
+[profile default]
+aws_secret_access_key = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+aws_access_key_id = xxxxxxxxxxxxxxxxxxxxxx
+region = eu-west-1
+
+[profile lab]
+aws_secret_access_key = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+aws_access_key_id = xxxxxxxxxxxxxxxxxxxxxx
+region = eu-west-1
+```
+
+--
+
+My Configuration below has 2 stacks, _mainVPC_ which has no __profile__ keyword defined will use the default profile configuration to deploy and _labVPC_ which has _lab_ defined as the profile, will deploy using the __lab__ credentials in my config above.
+
+```yaml
+# Stacks
+stacks:
+  mainVPC:
+    depends_on:
+      - labVPC
+
+    cf:
+      cidr: 10.10.0.0/24
+
+  labVPC:
+    profile: lab
+
+```
+Note that the _mainVPC_ depends_on on the _labVPC_, so what we have is a cross-account stack dependency.
+
+--
+
+The template below is for the __mainVPC__ stack defined in the config file above.
+
+```yaml
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: |
+  This is an example VPC deployed via Qaz
+
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: {{ .mainVPC.cidr }}
+
+Outputs:
+  vpcid:
+    Description: VPC ID
+    Value:  << stack_output "labVPC::vpcid" >>
+    Export:
+      Name: lap-vpc-id
+
+```
+Note the Outputs section, the Deploy-Time function `stack_output` is being used to export the Value of the _labVPC_ vpcid, in other words, the output of a stack in another account is being used as an export.

--- a/examples/multi-account/config.yml
+++ b/examples/multi-account/config.yml
@@ -15,7 +15,7 @@ stacks:
       - labVPC
 
     cf:
-      cidr: 10.0.0.0/24
+      cidr: 10.10.0.0/24
 
   labVPC:
     # specify profile based on aws credentials/config file

--- a/examples/multi-account/config.yml
+++ b/examples/multi-account/config.yml
@@ -1,0 +1,22 @@
+
+# AWS Region
+region: eu-west-1
+
+# Project Name
+project: multi
+
+# Global Stack Variables
+global:
+
+# Stacks
+stacks:
+  mainVPC:
+    depends_on:
+      - labVPC
+
+    cf:
+      cidr: 10.0.0.0/24
+
+  labVPC:
+    # specify profile based on aws credentials/config file
+    profile: lab

--- a/examples/multi-account/templates/labVPC.yml
+++ b/examples/multi-account/templates/labVPC.yml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: |
+  This is an example VPC deployed via Qaz!
+
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: {{ .mainVPC.cidr }}
+
+Outputs:
+  vpcid:
+    Description: VPC ID
+    Value:  !Ref VPC
+    Export:
+      Name: !Sub "${AWS::StackName}-vpcid"

--- a/examples/multi-account/templates/mainVPC.yml
+++ b/examples/multi-account/templates/mainVPC.yml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: |
+  This is an example VPC deployed via Qaz
+
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: {{ .mainVPC.cidr }}
+
+Outputs:
+  vpcid:
+    Description: VPC ID
+    Value:  << stack_output "labVPC::vpcid" >>
+    Export:
+      Name: lap-vpc-id


### PR DESCRIPTION
1.  Support for cross-account stack deployments now supported.

2. Cross-AWS-Profile deployments supported within a single configuration file.

3. Removed the Qaz banner when the command is run without flags.

4. Scaled down init command text
