### PR TITLE
add loop over int to template funcs

### DIFF
--- a/commands/functions.go
+++ b/commands/functions.go
@@ -168,6 +168,11 @@ var genTimeFunctions = template.FuncMap{
 
 	// kms-decrypt - Descrypts CipherText
 	"kms_decrypt": kmsDecrypt,
+
+	// loop - useful to range over an int (rather than a slice, map, or channel). see examples/loop
+	"loop": func(n int) []struct{} {
+		return make([]struct{}, n)
+	},
 }
 
 var deployTimeFunctions = template.FuncMap{
@@ -246,4 +251,9 @@ var deployTimeFunctions = template.FuncMap{
 
 	// kms-decrypt - Descrypts CipherText
 	"kms_decrypt": kmsDecrypt,
+
+	// loop - useful to range over an int (rather than a slice, map, or channel). see examples/loop
+	"loop": func(n int) []struct{} {
+		return make([]struct{}, n)
+	},
 }

--- a/examples/loop/config.yml
+++ b/examples/loop/config.yml
@@ -1,0 +1,15 @@
+# AWS Region
+region: us-east-1
+
+# Project Name
+project: testproj
+
+# Global Stack Variables
+global:
+
+# Stacks
+stacks:
+  teststack:
+    source: source.yml
+    cf:
+      num_hosts: 4

--- a/examples/loop/source.yml
+++ b/examples/loop/source.yml
@@ -1,0 +1,11 @@
+Description: Test Stack deployed by qaz
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  {{- range $i, $_ := loop .teststack.num_hosts }}
+  MyInstance{{ $i }}:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      InstanceType: "t2.nano"
+      KeyName: "mykey"
+      ImageID: "ami-e3c3b8f4"
+  {{- end -}}


### PR DESCRIPTION
Go templates can loop over slices, maps and channels, but as far as I know are
missing the ability to simply specify loop iterations as an integer. This
function adds that ability by generating a slice of `struct{}` to loop over.
Because `struct{}` takes up no space, this causes no memory allocation.

This functionality is useful (at the very least) to specify a variable number of
instances to create.