### PR TITLE
add cf value of "current" stack to template vars

### DIFF
--- a/commands/stack.go
+++ b/commands/stack.go
@@ -596,8 +596,7 @@ func (s *stack) deployTimeParser() error {
 	values := config.vars()
 
 	// Add metadata specific to the stack we're working with to the parser
-	values["stack"] = s.name
-	values["currentstack"] = values[s.name]
+	values["stack"] = values[s.name]
 	values["parameters"] = s.parameters
 
 	t.Execute(&doc, values)
@@ -629,8 +628,7 @@ func (s *stack) genTimeParser() error {
 	values := config.vars()
 
 	// Add metadata specific to the stack we're working with to the parser
-	values["stack"] = s.name
-	values["currentstack"] = values[s.name]
+	values["stack"] = values[s.name]
 	values["parameters"] = s.parameters
 
 	t.Execute(&doc, values)

--- a/commands/stack.go
+++ b/commands/stack.go
@@ -597,6 +597,7 @@ func (s *stack) deployTimeParser() error {
 
 	// Add metadata specific to the stack we're working with to the parser
 	values["stack"] = s.name
+	values["currentstack"] = values[s.name]
 	values["parameters"] = s.parameters
 
 	t.Execute(&doc, values)
@@ -629,6 +630,7 @@ func (s *stack) genTimeParser() error {
 
 	// Add metadata specific to the stack we're working with to the parser
 	values["stack"] = s.name
+	values["currentstack"] = values[s.name]
 	values["parameters"] = s.parameters
 
 	t.Execute(&doc, values)

--- a/examples/currentstack/config.yml
+++ b/examples/currentstack/config.yml
@@ -1,0 +1,16 @@
+region: us-east-1
+project: myproj
+
+global:
+
+stacks:
+  mystacksmall:
+    source: templates/single.yml
+    cf:
+      nodes: 2
+      instancetype: t2.nano
+  mystackbig:
+    source: templates/single.yml
+    cf:
+      nodes: 10
+      instancetype: c4.xlarge

--- a/examples/currentstack/templates/single.yml
+++ b/examples/currentstack/templates/single.yml
@@ -1,11 +1,11 @@
-Description: Test Stack deployed by qaz {{.currentstack}}
+Description: Test Stack deployed by qaz
 AWSTemplateFormatVersion: '2010-09-09'
 Resources:
-  {{- range $i, $_ := loop .currentstack.nodes }}
+  {{- range $i, $_ := loop .stack.nodes }}
   MyInstance{{ $i }}:
     Type: "AWS::EC2::Instance"
     Properties:
-      InstanceType: {{$.currentstack.instancetype}}
+      InstanceType: {{$.stack.instancetype}}
       KeyName: "mykey"
       ImageID: "ami-e3c3b8f4"
   {{- end -}}

--- a/examples/currentstack/templates/single.yml
+++ b/examples/currentstack/templates/single.yml
@@ -1,0 +1,11 @@
+Description: Test Stack deployed by qaz {{.currentstack}}
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  {{- range $i, $_ := loop .currentstack.nodes }}
+  MyInstance{{ $i }}:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      InstanceType: {{$.currentstack.instancetype}}
+      KeyName: "mykey"
+      ImageID: "ami-e3c3b8f4"
+  {{- end -}}


### PR DESCRIPTION
This gives templates a way to reference the parameters under "cf" in a stack the
config file without referencing a stack name directly. The "currentstack" key in
the map passed to the template will contain the "cf" map of the stack which is
being generated.

In this way, a single template can be used by multiple different stacks and have
different outputs.

If you can think of a cleaner way to achieve something like this, please let me know. I'm also very open to changing the name "currentstack". 

I'd also like to call out that this could be a backwards incompatibility if someone had a stack named "currentstack" already.