### PR TITLE
Config.yaml Fix

### DIFF
--- a/commands/helpers.go
+++ b/commands/helpers.go
@@ -2,11 +2,21 @@ package commands
 
 import "os"
 
+const (
+	defaultconfigA = "config.yml"
+	defaultconfigB = "config.yaml"
+)
+
 // DefaultConfig - sets config based on ENV variable or default config.yml
 func defaultConfig() string {
-	env := os.Getenv(configENV)
-	if env == "" {
-		return "config.yml"
+	if env := os.Getenv(configENV); env != "" {
+		return env
 	}
-	return env
+
+	if _, err := os.Stat(defaultconfigB); err == nil {
+		return defaultconfigB
+	}
+
+	return defaultconfigA
+
 }

--- a/commands/vars.go
+++ b/commands/vars.go
@@ -21,8 +21,7 @@ var (
 
 // config environment variable
 const (
-	configENV     = "QAZ_CONFIG"
-	defaultconfig = "config.yml"
+	configENV = "QAZ_CONFIG"
 
 	// OutputRegex for printing yaml/json output
 	OutputRegex = `(?m)^[ ]*([^\r\n:]+?)\s*:`

--- a/examples/vpc/config.yaml
+++ b/examples/vpc/config.yaml
@@ -1,0 +1,23 @@
+region: eu-west-1
+project: daidokoro
+
+global:
+  tags:
+    - code: go
+    - service: example
+    - life: live
+
+stacks:
+  vpc:
+    policy: https://s3-eu-west-1.amazonaws.com/daidokoro-dev/policies/stack.json
+    source: https://raw.githubusercontent.com/daidokoro/qaz/master/examples/vpc/templates/vpc.yml
+    cf:
+      cidr: 10.10.0.0/16
+
+  subnet:
+    depends_on:
+      - vpc
+    cf:
+      subnets:
+        - private: 10.10.0.0/24
+        - public: 10.10.2.0/24


### PR DESCRIPTION
Fix for #28 

Added support for _config.yaml_ to be detected in working directory by default.

Qaz will now check for config in the following order:

1. Environment Variable -> `QAZ_CONFIG`
2. _config.yaml_ file in working directory
3. defaults to _config.yml_ if no other config source is present.
