### PR TITLE
Session manager update & termination protection - v0.81-beta

### DIFF
--- a/commands/aws_lambda.go
+++ b/commands/aws_lambda.go
@@ -70,7 +70,7 @@ var invokeCmd = &cobra.Command{
 			return
 		}
 
-		sess, err := manager.GetSess(run.profile)
+		sess, err := GetSession()
 		utils.HandleError(err)
 
 		f := awsLambda{name: args[0]}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -73,7 +73,7 @@ var (
 			// Get Project & AWS Region
 			arrow := log.ColorString("->", "magenta")
 			project = utils.GetInput(fmt.Sprintf("%s Enter your Project name", arrow), "qaz-project")
-			region = utils.GetInput(fmt.Sprintf("%s Enter AWS Region", arrow), "eu-west-1")
+			region := utils.GetInput(fmt.Sprintf("%s Enter AWS Region", arrow), "eu-west-1")
 
 			// set target paths
 			c := filepath.Join(target, "config.yml")

--- a/commands/init.go
+++ b/commands/init.go
@@ -23,6 +23,11 @@ func init() {
 	gitDeployCmd.Flags().StringVarP(&run.gitpass, "password", "", "", "git password")
 	gitDeployCmd.Flags().StringVarP(&run.gitrsa, "ssh-rsa", "", filepath.Join(os.Getenv("HOME"), ".ssh/id_rsa"), "path to git SSH id_rsa")
 
+	// Define Git Status Command
+	gitStatusCmd.Flags().StringVarP(&run.gitrsa, "ssh-rsa", "", filepath.Join(os.Getenv("HOME"), ".ssh/id_rsa"), "path to git SSH id_rsa")
+	gitStatusCmd.Flags().StringVarP(&run.gitpass, "password", "", "", "git password")
+	gitStatusCmd.Flags().StringVarP(&run.gituser, "user", "u", "", "git username")
+
 	// Define Terminate Flags
 	terminateCmd.Flags().BoolVarP(&run.all, "all", "A", false, "terminate all stacks")
 
@@ -57,6 +62,7 @@ func init() {
 		generateCmd,
 		deployCmd,
 		gitDeployCmd,
+		gitStatusCmd,
 		policyCmd,
 		valuesCmd,
 		shellCmd,
@@ -103,6 +109,7 @@ func init() {
 		changeCmd,
 		policyCmd,
 		gitDeployCmd,
+		gitStatusCmd,
 		valuesCmd,
 		shellCmd,
 		protectCmd,

--- a/commands/init.go
+++ b/commands/init.go
@@ -29,17 +29,14 @@ func init() {
 	// Define Output Flags
 	outputsCmd.Flags().StringVarP(&run.profile, "profile", "p", "default", "configured aws profile")
 
-	// Define Exports Flags
-	exportsCmd.Flags().StringVarP(&region, "region", "r", "eu-west-1", "AWS Region")
-
 	// Define Root Flags
 	RootCmd.Flags().BoolVarP(&run.version, "version", "", false, "print current/running version")
 	RootCmd.PersistentFlags().BoolVarP(&run.colors, "no-colors", "", false, "disable colors in outputs")
 	RootCmd.PersistentFlags().StringVarP(&run.profile, "profile", "p", "default", "configured aws profile")
+	RootCmd.PersistentFlags().StringVarP(&run.region, "region", "r", "", "configured aws region: if blank, the region is acquired via the profile")
 	RootCmd.PersistentFlags().BoolVarP(&run.debug, "debug", "", false, "Run in debug mode...")
 
 	// Define Lambda Invoke Flags
-	invokeCmd.Flags().StringVarP(&region, "region", "r", "eu-west-1", "AWS Region")
 	invokeCmd.Flags().StringVarP(&run.funcEvent, "event", "e", "", "JSON Event data for AWS Lambda invoke")
 	invokeCmd.Flags().BoolVarP(&run.lambdAsync, "async", "x", false, "invoke lambda function asynchronously ")
 

--- a/commands/init.go
+++ b/commands/init.go
@@ -43,6 +43,10 @@ func init() {
 	// Define Changes Command
 	changeCmd.AddCommand(create, rm, list, execute, desc)
 
+	// Define Protect Command
+	protectCmd.Flags().BoolVarP(&run.protectOff, "off", "", false, "set termination protection to off")
+	protectCmd.Flags().BoolVarP(&run.all, "all", "A", false, "protect all stacks")
+
 	// Add Config --config common flag
 	for _, cmd := range []interface{}{
 		checkCmd,
@@ -56,6 +60,7 @@ func init() {
 		policyCmd,
 		valuesCmd,
 		shellCmd,
+		protectCmd,
 	} {
 		cmd.(*cobra.Command).Flags().StringVarP(&run.cfgSource, "config", "c", defaultConfig(), "path to config file")
 	}
@@ -100,6 +105,7 @@ func init() {
 		gitDeployCmd,
 		valuesCmd,
 		shellCmd,
+		protectCmd,
 	)
 
 }

--- a/commands/outputs.go
+++ b/commands/outputs.go
@@ -74,7 +74,7 @@ var (
 		Example: "qaz exports",
 		PreRun:  initialise,
 		Run: func(cmd *cobra.Command, args []string) {
-			sess, err := manager.GetSess(run.profile)
+			sess, err := GetSession()
 			utils.HandleError(err)
 			utils.HandleError(stks.Exports(sess))
 		},

--- a/commands/status.go
+++ b/commands/status.go
@@ -41,7 +41,7 @@ var (
 		},
 	}
 
-	// git-deploy command
+	// git-status command
 	gitStatusCmd = &cobra.Command{
 		Use:     "git-status [git-repo]",
 		Short:   "Check status of deployment via files stored in Git repository",

--- a/commands/vars.go
+++ b/commands/vars.go
@@ -10,7 +10,6 @@ import (
 var (
 	config  stks.Config
 	stacks  stks.Map
-	region  string
 	project string
 	gitrepo repo.Repo
 	log     = logger.Logger{
@@ -32,6 +31,7 @@ var run = struct {
 	cfgSource  string
 	tplSource  string
 	profile    string
+	region     string
 	tplSources []string
 	stacks     map[string]string
 	all        bool

--- a/commands/vars.go
+++ b/commands/vars.go
@@ -48,4 +48,5 @@ var run = struct {
 	gituser    string
 	gitpass    string
 	gitrsa     string
+	protectOff bool
 }{}

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,4 +1,4 @@
 package commands
 
 // Version
-const version = "v0.80-beta"
+const version = "v0.81-beta"

--- a/stacks/clouformation.go
+++ b/stacks/clouformation.go
@@ -211,7 +211,9 @@ func TerminateHandler(m *Map) {
 					return true
 				})
 
-				s.terminate()
+				if err := s.terminate(); err != nil {
+					Log.Error("error deleting stack: [%s] - %v", s.Name, err)
+				}
 				return
 			}
 

--- a/stacks/config.go
+++ b/stacks/config.go
@@ -23,6 +23,7 @@ type Config struct {
 		Parameters []map[string]string    `yaml:"parameters,omitempty" json:"parameters,omitempty" hcl:"parameters,omitempty"`
 		Policy     string                 `yaml:"policy,omitempty" json:"policy,omitempty" hcl:"policy,omitempty"`
 		Profile    string                 `yaml:"profile,omitempty" json:"profile,omitempty" hcl:"profile,omitempty"`
+		Region     string                 `yaml:"region,omitempty" json:"region,omitempty" hcl:"region,omitempty"`
 		Source     string                 `yaml:"source,omitempty" json:"source,omitempty" hcl:"source,omitempty"`
 		Bucket     string                 `yaml:"bucket,omitempty" json:"bucket,omitempty" hcl:"bucket,omitempty"`
 		Role       string                 `yaml:"role,omitempty" json:"role,omitempty" hcl:"role,omitempty"`

--- a/stacks/protect.go
+++ b/stacks/protect.go
@@ -1,0 +1,23 @@
+package stacks
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+// Protect - enables stack termination-protection
+func (s *Stack) Protect(enable *bool) error {
+	svc := cloudformation.New(s.Session, &aws.Config{Credentials: s.creds()})
+
+	params := &cloudformation.UpdateTerminationProtectionInput{
+		EnableTerminationProtection: aws.Bool(!*enable),
+		StackName:                   &s.Stackname,
+	}
+
+	Log.Debug("Calling [UpdateTerminationProtection] with parameters:\n%s"+"\n--\n", params)
+	if _, err := svc.UpdateTerminationProtection(params); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/stacks/services.go
+++ b/stacks/services.go
@@ -77,7 +77,7 @@ func tailWait(done <-chan bool, tailinput *TailServiceInput) {
 	for ch := time.Tick(time.Millisecond * 1300); ; <-ch {
 		select {
 		case <-done:
-			close(tail)
+			// close(tail)
 			return
 		default:
 			tail <- tailinput

--- a/stacks/stack.go
+++ b/stacks/stack.go
@@ -45,6 +45,7 @@ type Stack struct {
 	Tags           []*cloudformation.Tag
 	Session        *session.Session
 	Profile        string
+	Region         string
 	Source         string
 	Bucket         string
 	Role           string

--- a/stacks/terminate.go
+++ b/stacks/terminate.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *Stack) terminate() error {
-
+	Log.Debug("terminate called for: [%s]", s.Name)
 	if !s.StackExists() {
 		Log.Info("%s: does not exist...", s.Name)
 		return nil


### PR DESCRIPTION
This pull requests (v0.81-beta) adds the following features and bug fixes.

## Bug Fixes
- Added errror checking to terminating stacks. Fixes intermittent stack trace during termination commands in shell-mode

## Features
- _region_ can now be specified in config for each stack as a keyword. 
```yaml
stacks:
  mystack:
    region: us-east-1
    source: some.template
    cf:
      some: value
```

As each stack will have it's own session, the _stack_output_  gen-time template command can be used for cross-region output sharing, without the need to setting up a new AWS profile.


- Termination Protects can now be enabled for all stacks.
```sh
$ qaz protect --al --config some.yaml  # turns on protection for all
$ qaz protect --all --off --config some.yaml # turns off protection for all
```
Individual stacks can also be specified.
```
$ qaz protect mystack --config some.yaml
```

- git-status
A git-status command has been added. This command allows you to check the status of a deployment by calling the config file on a Git Repo directly.

```sh
qaz git-status https://github.com/cfn-deployable/simplevpc
```

```sh
info: fetching git repo: [simplevpc]
--
Counting objects: 14, done.
Total 14 (delta 0), reused 0 (delta 0), pack-reused 14
--
create_pending -> vpc [qaz-project-vpc]

```