### PR TITLE
Added new keyword 'stackname' to overwrite default stack name

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -57,6 +57,7 @@ func Configure(confSource string, conf string) (err error) {
 			DependsOn:      v.DependsOn,
 			Policy:         v.Policy,
 			Source:         v.Source,
+			Stackname:      v.Stackname,
 			Bucket:         v.Bucket,
 			Role:           v.Role,
 			DeployDelims:   &config.DeployDelimiter,

--- a/commands/config.go
+++ b/commands/config.go
@@ -57,7 +57,7 @@ func Configure(confSource string, conf string) (err error) {
 			DependsOn:      v.DependsOn,
 			Policy:         v.Policy,
 			Source:         v.Source,
-			Stackname:      v.Stackname,
+			Stackname:      v.Name,
 			Bucket:         v.Bucket,
 			Role:           v.Role,
 			DeployDelims:   &config.DeployDelimiter,

--- a/stacks/config.go
+++ b/stacks/config.go
@@ -25,6 +25,7 @@ type Config struct {
 		Profile    string                 `yaml:"profile,omitempty" json:"profile,omitempty" hcl:"profile,omitempty"`
 		Region     string                 `yaml:"region,omitempty" json:"region,omitempty" hcl:"region,omitempty"`
 		Source     string                 `yaml:"source,omitempty" json:"source,omitempty" hcl:"source,omitempty"`
+		Stackname  string                 `yaml:"stackname,omitempty" json:"stackname,omitempty" hcl:"stackname,omitempty"`
 		Bucket     string                 `yaml:"bucket,omitempty" json:"bucket,omitempty" hcl:"bucket,omitempty"`
 		Role       string                 `yaml:"role,omitempty" json:"role,omitempty" hcl:"role,omitempty"`
 		Tags       []map[string]string    `yaml:"tags,omitempty" json:"tags,omitempty" hcl:"tags,omitempty"`

--- a/stacks/config.go
+++ b/stacks/config.go
@@ -25,7 +25,7 @@ type Config struct {
 		Profile    string                 `yaml:"profile,omitempty" json:"profile,omitempty" hcl:"profile,omitempty"`
 		Region     string                 `yaml:"region,omitempty" json:"region,omitempty" hcl:"region,omitempty"`
 		Source     string                 `yaml:"source,omitempty" json:"source,omitempty" hcl:"source,omitempty"`
-		Stackname  string                 `yaml:"stackname,omitempty" json:"stackname,omitempty" hcl:"stackname,omitempty"`
+		Name       string                 `yaml:"name,omitempty" json:"name,omitempty" hcl:"name,omitempty"`
 		Bucket     string                 `yaml:"bucket,omitempty" json:"bucket,omitempty" hcl:"bucket,omitempty"`
 		Role       string                 `yaml:"role,omitempty" json:"role,omitempty" hcl:"role,omitempty"`
 		Tags       []map[string]string    `yaml:"tags,omitempty" json:"tags,omitempty" hcl:"tags,omitempty"`

--- a/stacks/stack.go
+++ b/stacks/stack.go
@@ -66,7 +66,9 @@ type Stack struct {
 
 // SetStackName - sets the stackname with struct
 func (s *Stack) SetStackName() {
-	s.Stackname = fmt.Sprintf("%s-%s", *s.Project, s.Name)
+	if s.Stackname == "" {
+		s.Stackname = fmt.Sprintf("%s-%s", *s.Project, s.Name)
+	}
 }
 
 // creds - Returns credentials if role set


### PR DESCRIPTION
By default a _stack_ defined in `config.xml` is finally named _project_-_stack_ in CloudFormation. While being a friend of rules and naming conventions, we have a few use cases where this convention does not fit: we have different accounts for non-prod and prod and a few common stacks being deployed in both accounts with different parameters. They share the same qaz source template, should be configured at a common place (likely in the same `config.yml`) and they should be named equally in both accounts for aesthetical and practical reasons (e.g. when it comes to CloudFormation output/export names prefixed by the stack name to keep them unique across the account).

This merge request allows me to handle those situations like this:

```yaml
# config.yml
project: infra
...
stacks:
  'bastion-preprod':
    source: bastion.template.yml
    stackname: infra-bastion
    profile: preprod
    ...
    tags:
      - CostReference: some-id-for-preprod
...
  'bastion-prod':
    source: bastion.template.yml
    stackname: infra-bastion
    profile: prod
    ...
    tags:
      - CostReference: some-id-for-prod
```
