### PR TITLE
Added feature bash/zsh completion

### DIFF
--- a/commands/completion.go
+++ b/commands/completion.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/daidokoro/qaz/utils"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [shell]",
+	Short: "Output shell completion code for the specified shell (bash or zsh)",
+	Example: strings.Join([]string{
+		"",
+		"qaz completion bash > $(brew --prefix)/etc/bash_completion.d/qaz",
+		"qaz completion zsh > \"${fpath[1]}/_qaz\"",
+	}, "\n"),
+	PreRun: initialise,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if len(args) == 0 {
+			utils.HandleError(fmt.Errorf("please specify shell"))
+
+		} else if len(args) > 1 {
+			utils.HandleError(fmt.Errorf("too many arguments, expected shell type only"))
+
+		} else {
+
+			if args[0] == "bash" {
+				RootCmd.GenBashCompletion(os.Stdout);
+			} else if args[0] == "zsh" {
+				RootCmd.GenZshCompletion(os.Stdout);
+			} else {
+				utils.HandleError(fmt.Errorf("Shell [%s] currently not supported", args[0]))
+			}
+
+		}
+
+	},
+}
+

--- a/commands/init.go
+++ b/commands/init.go
@@ -87,8 +87,8 @@ func init() {
 		execute,
 		desc,
 	} {
-		cmd.(*cobra.Command).Flags().StringVarP(&run.cfgSource, "config", "c", defaultConfig(), "path to config file [Required]")
-		cmd.(*cobra.Command).Flags().StringVarP(&run.stackName, "stack", "s", "", "Qaz local project Stack Name [Required]")
+		cmd.(*cobra.Command).Flags().StringVarP(&run.cfgSource, "config", "c", defaultConfig(), "path to config file (Required)")
+		cmd.(*cobra.Command).Flags().StringVarP(&run.stackName, "stack", "s", "", "Qaz local project Stack Name (Required)")
 	}
 
 	create.Flags().StringVarP(&run.tplSource, "template", "t", "", "path to template file Or stack::url")

--- a/commands/init.go
+++ b/commands/init.go
@@ -113,6 +113,7 @@ func init() {
 		valuesCmd,
 		shellCmd,
 		protectCmd,
+		completionCmd,
 	)
 
 }


### PR DESCRIPTION
It is now possible to let cobra generate autocompletion code for bash and zsh by using a new `completion` command like this:

```bash
# for current bash session
qaz completion bash > /tmp/qaz-completion.sh
source /tmp/qaz-completion.sh

# for future bash sessions if using homebrew
qaz completion bash > $(brew --prefix)/etc/bash_completion.d/qaz

# for current zsh session
source <(qaz completion zsh)

# for future zsh sessions
qaz completion zsh > "${fpath[1]}/_qaz"
```

The resulting completion script could be improved by implementing autocompletion for config files, stack names and profiles like this (here: zsh, note the `:profile:_profiles` and `:stack:_stacks` extension to refer the custom functions `_profile` and `_stacks` in the argument description)

```bash
function _stacks {
  # warning: this operates on the default config.yml and does not consider a previously given config file using the -c|--config option
  local -a stacks
  stacks=( $(echo "ls" | qaz shell | awk 'NR>5{flag=1}/EOF/{flag=0}flag' | sort) )
  _describe 'stack'  stacks
}

function _profiles {
  local -a profiles
  profiles=( $( cat ~/.aws/credentials 2>/dev/null | sed -n "s/^\[\(.*\)\]$/\1/p" | sort) )
  _describe 'profile' profiles
}

function _qaz {
  local -a commands

  _arguments -C \
    '--debug[Run in debug mode...]' \
    '--no-colors[disable colors in outputs]' \
    '(-p --profile)'{-p,--profile}'[configured aws profile]:profile:_profiles' \
...
function _qaz_change_create {
  _arguments \
    '(-c --config)'{-c,--config}'[path to config file (Required)]:filename:_files' \
    '(-s --stack)'{-s,--stack}'[Qaz local project Stack Name (Required)]:stack:_stacks' \
...
```

The full extended completion script can be found here: https://gist.githubusercontent.com/thorstenhuhn/7a8356cc57cc07d120eb2e4edb111790/raw/4372f7a280a2116b8dcf3eaa4f0ef2b47318cbe4/_qaz
