### PR TITLE
Added title function

### DIFF
--- a/commands/functions.go
+++ b/commands/functions.go
@@ -200,6 +200,12 @@ var (
 			return seq
 		},
 
+		// capitalize first letter
+		"title": func(s string) string {
+			log.Debug("Calling Template Function [title] with arguments: %s", s)
+			return strings.Title(s)
+		},
+
 	}
 
 	// deploytime function maps


### PR DESCRIPTION
Brings https://golang.org/pkg/strings/#Title function to life, useful when using variables in Camel Case notation