### PR TITLE
Added new lint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,18 @@ Usage:
 Available Commands:
   change      Change-Set management for AWS Stacks
   check       Validates Cloudformation Templates
+  completion  Output shell completion code for the specified shell (bash or zsh)
   deploy      Deploys stack(s) to AWS
   exports     Prints stack exports
   generate    Generates template from configuration values
   git-deploy  Deploy project from Git repository
+  git-status  Check status of deployment via files stored in Git repository
   help        Help about any command
   init        Creates an initial Qaz config file
   invoke      Invoke AWS Lambda Functions
+  lint        Validates stack by calling cfn-lint
   outputs     Prints stack outputs
+  protect     Enables stack termination protection
   set-policy  Set Stack Policies based on configured value
   shell       Qaz interactive shell - loads the specified config into an interactive shell
   status      Prints status of deployed/un-deployed stacks

--- a/commands/init.go
+++ b/commands/init.go
@@ -67,6 +67,7 @@ func init() {
 		valuesCmd,
 		shellCmd,
 		protectCmd,
+		lintCmd,
 	} {
 		cmd.(*cobra.Command).Flags().StringVarP(&run.cfgSource, "config", "c", defaultConfig(), "path to config file")
 	}
@@ -76,6 +77,7 @@ func init() {
 		generateCmd,
 		updateCmd,
 		checkCmd,
+		lintCmd,
 	} {
 		cmd.(*cobra.Command).Flags().StringVarP(&run.tplSource, "template", "t", "", "path to template source Or stack::source")
 	}
@@ -114,6 +116,7 @@ func init() {
 		shellCmd,
 		protectCmd,
 		completionCmd,
+		lintCmd,
 	)
 
 }

--- a/commands/lint.go
+++ b/commands/lint.go
@@ -57,10 +57,7 @@ var lintCmd = &cobra.Command{
 		content := []byte(stacks.MustGet(s).Template)
 		filename := fmt.Sprintf(".%s.qaz", s)
 		writeErr := ioutil.WriteFile(filename, content, 0644)
-		if writeErr != nil {
-			utils.HandleError(writeErr)
-			return
-		}
+		utils.HandleError(writeErr)
 
 		// run cfn-lint against temporary file
 		binary, lookErr := exec.LookPath("cfn-lint")
@@ -71,9 +68,7 @@ var lintCmd = &cobra.Command{
 		cmdArgs := []string{"cfn-lint", filename}
 		env := os.Environ()
 		execErr := syscall.Exec(binary, cmdArgs, env)
-		if execErr != nil {
-			utils.HandleError(execErr)
-		}
+		utils.HandleError(execErr)
 
 	},
 }

--- a/commands/lint.go
+++ b/commands/lint.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/daidokoro/qaz/utils"
+
+	"github.com/spf13/cobra"
+)
+
+var lintCmd = &cobra.Command{
+	Use:   "lint [stack]",
+	Short: "Validates stack by calling cfn-lint",
+	Example: strings.Join([]string{
+		"",
+		"qaz lint -c config.yml -t stack::source",
+		"qaz lint vpc -c config.yml",
+	}, "\n"),
+	PreRun: initialise,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		var s string
+		var source string
+
+		err := Configure(run.cfgSource, run.cfgRaw)
+		utils.HandleError(err)
+
+		switch {
+		case run.tplSource != "":
+			s, source, err = utils.GetSource(run.tplSource)
+			utils.HandleError(err)
+		case len(args) > 0:
+			s = args[0]
+		}
+
+		// check if stack exists in config
+		if _, ok := stacks.Get(s); !ok {
+			utils.HandleError(fmt.Errorf("Stack [%s] not found in config", s))
+			return
+		}
+
+		// if source is defined via cli arg
+		if source != "" {
+			stacks.MustGet(s).Source = source
+		}
+
+		name := fmt.Sprintf("%s-%s", project, s)
+		log.Debug("generating a template for %s", name)
+		utils.HandleError(stacks.MustGet(s).GenTimeParser())
+
+		// write template to temporary file
+		content := []byte(stacks.MustGet(s).Template)
+		filename := fmt.Sprintf(".%s.qaz", s)
+		writeErr := ioutil.WriteFile(filename, content, 0644)
+		if writeErr != nil {
+			utils.HandleError(writeErr)
+			return
+		}
+
+		// run cfn-lint against temporary file
+		binary, lookErr := exec.LookPath("cfn-lint")
+		if lookErr != nil {
+			utils.HandleError(fmt.Errorf("cfn-lint executable not found! Please consider https://pypi.org/project/cfn-lint/ for help."))
+			return
+		}
+		cmdArgs := []string{"cfn-lint", filename}
+		env := os.Environ()
+		execErr := syscall.Exec(binary, cmdArgs, env)
+		if execErr != nil {
+			utils.HandleError(execErr)
+		}
+
+	},
+}

--- a/commands/lint.go
+++ b/commands/lint.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 
 	"github.com/daidokoro/qaz/utils"
 
@@ -60,14 +59,15 @@ var lintCmd = &cobra.Command{
 		utils.HandleError(writeErr)
 
 		// run cfn-lint against temporary file
-		binary, lookErr := exec.LookPath("cfn-lint")
+		_, lookErr := exec.LookPath("cfn-lint")
 		if lookErr != nil {
 			utils.HandleError(fmt.Errorf("cfn-lint executable not found! Please consider https://pypi.org/project/cfn-lint/ for help."))
-			return
 		}
-		cmdArgs := []string{"cfn-lint", filename}
-		env := os.Environ()
-		execErr := syscall.Exec(binary, cmdArgs, env)
+		execCmd := exec.Command("cfn-lint", filename)
+		execCmd.Env = append(os.Environ())
+		execCmd.Stdout = os.Stdout
+		execCmd.Stderr = os.Stderr
+		execErr := execCmd.Run()
 		utils.HandleError(execErr)
 
 	},

--- a/commands/shell.go
+++ b/commands/shell.go
@@ -3,15 +3,15 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-  "io/ioutil"
+	"io/ioutil"
 	"math/rand"
-  "os"
-  "os/exec"
+	"os"
+	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
-  "syscall"
+	"syscall"
 
 	"github.com/daidokoro/qaz/utils"
 
@@ -530,10 +530,7 @@ func initShell(p string, s *ishell.Shell) {
 				content := []byte(stacks.MustGet(s).Template)
 				filename := fmt.Sprintf(".%s.qaz", s)
 				writeErr := ioutil.WriteFile(filename, content, 0644)
-				if writeErr != nil {
-					utils.HandleError(writeErr)
-					return
-				}
+				utils.HandleError(writeErr)
 
 				// run cfn-lint against temporary file
 				binary, lookErr := exec.LookPath("cfn-lint")
@@ -544,10 +541,7 @@ func initShell(p string, s *ishell.Shell) {
 				cmdArgs := []string{"cfn-lint", filename}
 				env := os.Environ()
 				execErr := syscall.Exec(binary, cmdArgs, env)
-				if execErr != nil {
-					utils.HandleError(execErr)
-					return
-				}
+				utils.HandleError(execErr)
 
 			},
 		},


### PR DESCRIPTION
`cfn-lint` (https://pypi.org/project/cfn-lint/) goes beyond syntax checking and validates CloudFormation templates against the CloudFormation spec. This commit implements a `lint` command to provide the output of a `cfn-lint` call on the generated template.
Unfortunately I found nothing comparable natively implemented in Golang.