### PR TITLE
Added new parameters command

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -34,6 +34,9 @@ func init() {
 	// Define Output Flags
 	outputsCmd.Flags().StringVarP(&run.profile, "profile", "p", "default", "configured aws profile")
 
+	// Define Parameter Flags
+	parametersCmd.Flags().StringVarP(&run.profile, "profile", "p", "default", "configured aws profile")
+
 	// Define Root Flags
 	RootCmd.Flags().BoolVarP(&run.version, "version", "", false, "print current/running version")
 	RootCmd.PersistentFlags().BoolVarP(&run.colors, "no-colors", "", false, "disable colors in outputs")
@@ -71,6 +74,7 @@ func init() {
 		shellCmd,
 		protectCmd,
 		lintCmd,
+		parametersCmd,
 	} {
 		cmd.(*cobra.Command).Flags().StringVarP(&run.cfgSource, "config", "c", defaultConfig(), "path to config file")
 	}
@@ -120,6 +124,7 @@ func init() {
 		protectCmd,
 		completionCmd,
 		lintCmd,
+		parametersCmd,
 	)
 
 }

--- a/commands/outputs.go
+++ b/commands/outputs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"sync"
 	"text/tabwriter"
 
@@ -112,11 +113,15 @@ var (
 						return
 					}
 
-					for _, i := range stacks.MustGet(s).Output.Stacks {
+					for _, stack := range stacks.MustGet(s).Output.Stacks {
 
 						w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, '.', 0)
+						// sort parameters by key
+						sort.Slice(stack.Parameters, func(i, j int) bool {
+							return *stack.Parameters[i].ParameterKey < *stack.Parameters[j].ParameterKey
+						})
 						// iterate over deployed stack parameters
-						for _, p := range i.Parameters {
+						for _, p := range stack.Parameters {
 							fmt.Fprintf(w, "%s\t %s", log.ColorString(*p.ParameterKey, "cyan"), *p.ParameterValue)
 							// find corresponding parameter in local qaz config
 							for _, pl := range stacks.MustGet(s).Parameters {


### PR DESCRIPTION
When collaborating in a team there might be a good chance of changes not being committed in time. In addition people might decide to update stack parameters directly using the AWS console, leading to a Qaz `config.yml` not resembling the latest parameter values. Updating the stack using `qaz update` would revert those external changes. While recommending the use of the new `--interactive` option for updates to at least recognize unexpected changes, a command to check the _remote_ stack parameter values against the local values might deliver the cause.

```bash
▶ qaz parameters my-fancy-app-stack
Environment................. tst
InstanceType................ t3.xlarge
VolumeSize.................. 100
AmiId....................... ami-076431be05aaf8080 vs. ami-0ec1ba09723e5bfac
AsgSize..................... 3
WaitForSuccessSignal........ true
```

`qaz parameters` prints the parameter names and values of the deployed stack and compares against the values in the local `config.yml`. In this example, the values of `AmiId` have diverged, leading to the extra output `vs. ami-0ec1ba09723e5bfac`.